### PR TITLE
Remove misplaced inline.

### DIFF
--- a/socket_packet_utils.c
+++ b/socket_packet_utils.c
@@ -111,7 +111,7 @@ typedef struct {
 } serv_socket_state_t;
 
 // Accept connection
-inline void acceptConnection(serv_socket_state_t * s)
+void acceptConnection(serv_socket_state_t * s)
 {
   if (s->conn != -1) return;
   if (s->sock == -1) serv_socket_init((unsigned long long) s);


### PR DESCRIPTION
This code assumes gnu89 semantics for the inline keyword and so linking
fails with any vaguely modern compiler.